### PR TITLE
Get spice time as well

### DIFF
--- a/src/import.coffee
+++ b/src/import.coffee
@@ -116,6 +116,8 @@ Brauhaus.Recipe.fromBeerXml = (xml) ->
                                     spice.weight = parseFloat spiceProperty.textContent
                                 when 'alpha'
                                     spice.aa = parseFloat spiceProperty.textContent
+                                when 'time'
+                                    spice.time = parseFloat spiceProperty.textContent
                                 when 'use'
                                     spice.use = spiceProperty.textContent
                                 when 'form'


### PR DESCRIPTION
I want to convert beerxml recipes to Speidel format, for uploading directly to my Speidel. The hop addition times are important, this was missing.